### PR TITLE
Set metis to use double reals.

### DIFF
--- a/metis/include/metis.h
+++ b/metis/include/metis.h
@@ -40,7 +40,7 @@
    32 : single precission floating point (float)
    64 : double precission floating point (double)
 --------------------------------------------------------------------------*/
-#define REALTYPEWIDTH 32
+#define REALTYPEWIDTH 64
 
 
 


### PR DESCRIPTION
Iron needs to use metis/parmetis with double precision real numbers so set metis accordingly.
